### PR TITLE
Add PyTorch training pipeline for chip performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
 # Quantum-Chip
 
-This repository provides a minimal PyTorch pipeline for estimating the performance of superconducting quantum chips using paired TEM and AFM images.
+This repository offers a minimal PyTorch pipeline for estimating the performance of superconducting quantum chips from paired TEM and AFM images.
 
-## Dataset format
+## Contents
 
-Create a CSV file where each row describes a chip with the following columns:
+1. [Dataset](#dataset)
+2. [Training](#training)
+3. [Interactive options](#interactive-options)
+4. [Speech notifications](#speech-notifications)
+
+## Dataset
+
+Create a CSV file where each row describes a chip:
 
 ```
 tem_path,afm_path,performance
 /path/to/chip1_tem.png,/path/to/chip1_afm.png,0.85
 ```
+
+Each image pair is loaded, resized to 224×224, stacked as a two-channel tensor and mapped to the numeric performance value.
 
 ## Training
 
@@ -17,9 +26,30 @@ tem_path,afm_path,performance
 python train.py --csv path/to/data.csv --epochs 20 --output model.pt
 ```
 
-The script reads the CSV, stacks each chip's TEM and AFM images as a two-channel tensor, and trains a modified ResNet-18 to predict the measured performance value.
+The script reads the CSV, trains a modified ResNet‑18 and saves weights to `model.pt`.
 
 ### Interactive options
 
-- `--ui` opens a file dialog to choose the CSV instead of specifying `--csv` on the command line.
-- `--plot` displays a live plot of training and validation loss. Progress bars with remaining time are always shown in the console.
+- `--ui` opens a file dialog to choose the CSV.
+- `--plot` shows a live plot of training/validation loss and progress bars with ETA.
+
+## Speech notifications
+
+Add spoken feedback with language buttons:
+
+```
+python train.py --csv path/to/data.csv --speak
+```
+
+Click the desired button in the pop-up window to switch among:
+
+| Code | Language |
+|------|----------|
+| zh   | 中文 |
+| en   | English |
+| de   | Deutsch |
+| fr   | Français |
+| es   | Español |
+| el   | Ελληνικά |
+
+Every epoch completion is announced in the selected language (requires `pyttsx3`).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Quantum-Chip
+
+This repository provides a minimal PyTorch pipeline for estimating the performance of superconducting quantum chips using paired TEM and AFM images.
+
+## Dataset format
+
+Create a CSV file where each row describes a chip with the following columns:
+
+```
+tem_path,afm_path,performance
+/path/to/chip1_tem.png,/path/to/chip1_afm.png,0.85
+```
+
+## Training
+
+```
+python train.py --csv path/to/data.csv --epochs 20 --output model.pt
+```
+
+The script reads the CSV, stacks each chip's TEM and AFM images as a two-channel tensor, and trains a modified ResNet-18 to predict the measured performance value.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ python train.py --csv path/to/data.csv --epochs 20 --output model.pt
 ```
 
 The script reads the CSV, stacks each chip's TEM and AFM images as a two-channel tensor, and trains a modified ResNet-18 to predict the measured performance value.
+
+### Interactive options
+
+- `--ui` opens a file dialog to choose the CSV instead of specifying `--csv` on the command line.
+- `--plot` displays a live plot of training and validation loss. Progress bars with remaining time are always shown in the console.

--- a/dataset.py
+++ b/dataset.py
@@ -1,0 +1,41 @@
+import csv
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image
+import torch
+from torch.utils.data import Dataset
+from torchvision import transforms
+
+
+class SuperconductingChipDataset(Dataset):
+    """Dataset for TEM/AFM images and chip performance labels."""
+
+    def __init__(self, csv_file: str, transform: Optional[transforms.Compose] = None) -> None:
+        self.csv_path = Path(csv_file)
+        self.transform = transform or transforms.ToTensor()
+        self.samples = []
+        with self.csv_path.open() as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                # Expect columns: tem_path, afm_path, performance
+                self.samples.append(
+                    {
+                        "tem_path": Path(row["tem_path"]),
+                        "afm_path": Path(row["afm_path"]),
+                        "performance": float(row["performance"]),
+                    }
+                )
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, idx: int):
+        sample = self.samples[idx]
+        tem_img = Image.open(sample["tem_path"]).convert("L")
+        afm_img = Image.open(sample["afm_path"]).convert("L")
+        tem_tensor = self.transform(tem_img)
+        afm_tensor = self.transform(afm_img)
+        image = torch.cat([tem_tensor, afm_tensor], dim=0)  # (2, H, W)
+        performance = torch.tensor(sample["performance"], dtype=torch.float32)
+        return image, performance

--- a/model.py
+++ b/model.py
@@ -1,0 +1,19 @@
+import torch.nn as nn
+import torchvision.models as models
+
+
+class ChipPerformanceNet(nn.Module):
+    """Predict chip performance from stacked TEM and AFM images."""
+
+    def __init__(self, pretrained: bool = False) -> None:
+        super().__init__()
+        weights = models.ResNet18_Weights.DEFAULT if pretrained else None
+        self.backbone = models.resnet18(weights=weights)
+        # Replace first conv to accept two-channel input
+        self.backbone.conv1 = nn.Conv2d(2, 64, kernel_size=7, stride=2, padding=3, bias=False)
+        # Replace classification head with regression output
+        in_features = self.backbone.fc.in_features
+        self.backbone.fc = nn.Linear(in_features, 1)
+
+    def forward(self, x):
+        return self.backbone(x).squeeze(1)

--- a/speech.py
+++ b/speech.py
@@ -1,0 +1,33 @@
+LANGUAGES = {
+    'en': {'name': 'English', 'epoch': 'Epoch {epoch}/{total} completed. Validation loss {val_loss:.4f}'},
+    'zh': {'name': '中文', 'epoch': '第 {epoch}/{total} 轮完成。验证损失 {val_loss:.4f}'},
+    'de': {'name': 'Deutsch', 'epoch': 'Epoche {epoch}/{total} abgeschlossen. Validierungsverlust {val_loss:.4f}'},
+    'fr': {'name': 'Français', 'epoch': "Époque {epoch}/{total} terminée. Perte de validation {val_loss:.4f}"},
+    'es': {'name': 'Español', 'epoch': 'Época {epoch}/{total} completada. Pérdida de validación {val_loss:.4f}'},
+    'el': {'name': 'Ελληνικά', 'epoch': 'Εποχή {epoch}/{total} ολοκληρώθηκε. Απώλεια επικύρωσης {val_loss:.4f}'},
+}
+
+
+def get_message(lang: str, key: str, **kwargs) -> str:
+    data = LANGUAGES.get(lang, LANGUAGES['en'])
+    template = data.get(key, '')
+    return template.format(**kwargs)
+
+
+def speak_message(lang: str, key: str, **kwargs) -> None:
+    text = get_message(lang, key, **kwargs)
+    try:
+        import pyttsx3
+    except Exception:
+        return
+    engine = pyttsx3.init()
+    try:
+        for voice in engine.getProperty('voices'):
+            langs = getattr(voice, 'languages', [])
+            if any(lang in str(l).lower() for l in langs):
+                engine.setProperty('voice', voice.id)
+                break
+    except Exception:
+        pass
+    engine.say(text)
+    engine.runAndWait()

--- a/tests/test_dataset_model.py
+++ b/tests/test_dataset_model.py
@@ -1,0 +1,38 @@
+import csv
+import sys
+from pathlib import Path
+
+from PIL import Image
+import torch
+import torchvision.transforms as transforms
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from dataset import SuperconductingChipDataset
+from model import ChipPerformanceNet
+
+
+def create_dummy_data(tmpdir: Path) -> Path:
+    tem_path = tmpdir / "tem.png"
+    afm_path = tmpdir / "afm.png"
+    Image.new("L", (32, 32), color=0).save(tem_path)
+    Image.new("L", (32, 32), color=0).save(afm_path)
+
+    csv_path = tmpdir / "data.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["tem_path", "afm_path", "performance"])
+        writer.writeheader()
+        writer.writerow({"tem_path": str(tem_path), "afm_path": str(afm_path), "performance": "0.9"})
+    return csv_path
+
+
+def test_dataset_and_model(tmp_path):
+    csv_file = create_dummy_data(tmp_path)
+    ds = SuperconductingChipDataset(csv_file, transform=transforms.ToTensor())
+    image, target = ds[0]
+    assert image.shape[0] == 2
+    model = ChipPerformanceNet(pretrained=False)
+    model.eval()
+    with torch.no_grad():
+        output = model(image.unsqueeze(0))
+    assert output.shape == torch.Size([1])

--- a/tests/test_speech.py
+++ b/tests/test_speech.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from speech import LANGUAGES, get_message
+
+
+def test_language_messages():
+    required = {'en', 'zh', 'de', 'fr', 'es', 'el'}
+    assert required.issubset(LANGUAGES)
+    for code in required:
+        msg = get_message(code, 'epoch', epoch=1, total=2, val_loss=0.5)
+        assert '1/2' in msg

--- a/train.py
+++ b/train.py
@@ -1,9 +1,10 @@
 import argparse
-from pathlib import Path
+import time
 
 import torch
 from torch.utils.data import DataLoader, random_split
 import torchvision.transforms as transforms
+from tqdm import tqdm
 
 from dataset import SuperconductingChipDataset
 from model import ChipPerformanceNet
@@ -34,9 +35,19 @@ def train(args):
     criterion = torch.nn.MSELoss()
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
 
+    train_losses, val_losses, epoch_times = [], [], []
+
+    if args.plot:
+        import matplotlib.pyplot as plt
+        plt.ion()
+        fig, ax = plt.subplots()
+
     for epoch in range(args.epochs):
+        start = time.time()
         model.train()
-        for images, targets in train_loader:
+        running_loss = 0.0
+        pbar = tqdm(train_loader, desc=f"Epoch {epoch + 1}/{args.epochs}", leave=False)
+        for images, targets in pbar:
             images = images.to(device)
             targets = targets.to(device)
             preds = model(images)
@@ -44,6 +55,10 @@ def train(args):
             optimizer.zero_grad()
             loss.backward()
             optimizer.step()
+            running_loss += loss.item() * images.size(0)
+            pbar.set_postfix(loss=loss.item())
+        running_loss /= len(train_loader.dataset)
+        train_losses.append(running_loss)
 
         model.eval()
         val_loss = 0.0
@@ -54,7 +69,21 @@ def train(args):
                 preds = model(images)
                 val_loss += criterion(preds, targets).item() * images.size(0)
         val_loss /= len(val_loader.dataset)
-        print(f"Epoch {epoch + 1}: val_loss={val_loss:.4f}")
+        val_losses.append(val_loss)
+
+        epoch_time = time.time() - start
+        epoch_times.append(epoch_time)
+        remaining = (args.epochs - epoch - 1) * (sum(epoch_times) / len(epoch_times))
+        print(f"Epoch {epoch + 1}: val_loss={val_loss:.4f} ETA:{remaining:.1f}s")
+
+        if args.plot:
+            ax.clear()
+            ax.plot(range(1, len(train_losses) + 1), train_losses, label="train")
+            ax.plot(range(1, len(val_losses) + 1), val_losses, label="val")
+            ax.set_xlabel("Epoch")
+            ax.set_ylabel("Loss")
+            ax.legend()
+            plt.pause(0.001)
 
     torch.save(model.state_dict(), args.output)
     print(f"Model saved to {args.output}")
@@ -62,12 +91,29 @@ def train(args):
 
 def main():
     parser = argparse.ArgumentParser(description="Train chip performance predictor")
-    parser.add_argument("--csv", type=str, required=True, help="CSV with tem_path, afm_path, performance")
+    parser.add_argument("--csv", type=str, help="CSV with tem_path, afm_path, performance")
     parser.add_argument("--output", type=str, default="model.pt")
     parser.add_argument("--epochs", type=int, default=10)
     parser.add_argument("--batch_size", type=int, default=8)
     parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--ui", action="store_true", help="Use file dialog to select CSV if not provided")
+    parser.add_argument("--plot", action="store_true", help="Show real-time training plot")
     args = parser.parse_args()
+
+    if args.ui or not args.csv:
+        try:
+            import tkinter as tk
+            from tkinter import filedialog
+            root = tk.Tk()
+            root.withdraw()
+            file_path = filedialog.askopenfilename(filetypes=[("CSV files", "*.csv")])
+            if file_path:
+                args.csv = file_path
+        except Exception as exc:
+            raise RuntimeError(f"File dialog failed: {exc}")
+    if not args.csv:
+        parser.error("CSV file must be provided")
+
     train(args)
 
 

--- a/train.py
+++ b/train.py
@@ -1,4 +1,5 @@
 import argparse
+import threading
 import time
 
 import torch
@@ -8,6 +9,7 @@ from tqdm import tqdm
 
 from dataset import SuperconductingChipDataset
 from model import ChipPerformanceNet
+from speech import LANGUAGES, speak_message
 
 
 def get_device() -> torch.device:
@@ -18,7 +20,7 @@ def get_device() -> torch.device:
     return torch.device("cpu")
 
 
-def train(args):
+def train(args, selected_lang):
     transform = transforms.Compose([
         transforms.Resize((224, 224)),
         transforms.ToTensor(),
@@ -75,6 +77,8 @@ def train(args):
         epoch_times.append(epoch_time)
         remaining = (args.epochs - epoch - 1) * (sum(epoch_times) / len(epoch_times))
         print(f"Epoch {epoch + 1}: val_loss={val_loss:.4f} ETA:{remaining:.1f}s")
+        if args.speak:
+            speak_message(selected_lang["code"], "epoch", epoch=epoch + 1, total=args.epochs, val_loss=val_loss)
 
         if args.plot:
             ax.clear()
@@ -98,6 +102,7 @@ def main():
     parser.add_argument("--lr", type=float, default=1e-3)
     parser.add_argument("--ui", action="store_true", help="Use file dialog to select CSV if not provided")
     parser.add_argument("--plot", action="store_true", help="Show real-time training plot")
+    parser.add_argument("--speak", action="store_true", help="Enable voice notifications with language buttons")
     args = parser.parse_args()
 
     if args.ui or not args.csv:
@@ -114,7 +119,18 @@ def main():
     if not args.csv:
         parser.error("CSV file must be provided")
 
-    train(args)
+    selected_lang = {"code": "en"}
+    if args.speak:
+        try:
+            import tkinter as tk
+            root = tk.Tk()
+            root.title("Select language")
+            for code, data in LANGUAGES.items():
+                tk.Button(root, text=data["name"], command=lambda c=code: selected_lang.__setitem__("code", c)).pack(side=tk.LEFT)
+            threading.Thread(target=root.mainloop, daemon=True).start()
+        except Exception as exc:
+            print(f"Language selector failed: {exc}")
+    train(args, selected_lang)
 
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -1,0 +1,75 @@
+import argparse
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader, random_split
+import torchvision.transforms as transforms
+
+from dataset import SuperconductingChipDataset
+from model import ChipPerformanceNet
+
+
+def get_device() -> torch.device:
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        return torch.device("xpu")
+    return torch.device("cpu")
+
+
+def train(args):
+    transform = transforms.Compose([
+        transforms.Resize((224, 224)),
+        transforms.ToTensor(),
+    ])
+    dataset = SuperconductingChipDataset(args.csv, transform=transform)
+    train_size = int(0.8 * len(dataset))
+    val_size = len(dataset) - train_size
+    train_ds, val_ds = random_split(dataset, [train_size, val_size])
+    train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True)
+    val_loader = DataLoader(val_ds, batch_size=args.batch_size)
+
+    device = get_device()
+    model = ChipPerformanceNet(pretrained=True).to(device)
+    criterion = torch.nn.MSELoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+    for epoch in range(args.epochs):
+        model.train()
+        for images, targets in train_loader:
+            images = images.to(device)
+            targets = targets.to(device)
+            preds = model(images)
+            loss = criterion(preds, targets)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+        model.eval()
+        val_loss = 0.0
+        with torch.no_grad():
+            for images, targets in val_loader:
+                images = images.to(device)
+                targets = targets.to(device)
+                preds = model(images)
+                val_loss += criterion(preds, targets).item() * images.size(0)
+        val_loss /= len(val_loader.dataset)
+        print(f"Epoch {epoch + 1}: val_loss={val_loss:.4f}")
+
+    torch.save(model.state_dict(), args.output)
+    print(f"Model saved to {args.output}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train chip performance predictor")
+    parser.add_argument("--csv", type=str, required=True, help="CSV with tem_path, afm_path, performance")
+    parser.add_argument("--output", type=str, default="model.pt")
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--batch_size", type=int, default=8)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    args = parser.parse_args()
+    train(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement dataset class to pair TEM and AFM images with performance labels
- add ResNet-based regression model and training script
- include unit test and update documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aed841a844832fa2ddf49ac4dca64a